### PR TITLE
Throttling decorator fixed to work with Python 3

### DIFF
--- a/security/decorators.py
+++ b/security/decorators.py
@@ -10,7 +10,7 @@ def throttling(*validators):
     def decorator(view_func):
 
         def _throttling(self, *args, **kwargs):
-            map(lambda validator: validator.validate(self.request), validators)
+            [v.validate(self.request) for v in validators]
             return view_func(self, *args, **kwargs)
         return wraps(view_func, assigned=available_attrs(view_func))(_throttling)
 


### PR DESCRIPTION
Map inside the decorator was not evaluated in Python 3 as it returns a generator instead of evaluating the given function on each element of the iterable. Therefore, the validate method was not called on the validators.