### PR TITLE
Fixed two Python 3 related bugs

### DIFF
--- a/security/compatibility.py
+++ b/security/compatibility.py
@@ -1,0 +1,6 @@
+import six
+
+
+def extract_headers(response):
+    """Extracts headers from httplib response or http.client response based on used version off Python."""
+    return response.headers if six.PY2 else response.headers._headers


### PR DESCRIPTION
* logging suds requests does not crash under Python 3
  (request kwargs are cast from bytes to str if necessary)
* incompatibility between httplib and http.client in extracting
  response headers fixed